### PR TITLE
Pull 435 - apply markdown linter suggestion

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -59,7 +59,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Lint Markdown
-        uses: DavidAnson/markdownlint-cli2-action@05f32210e84442804257b2a6f20b273450ec8265 # v19.1.0
+        uses: DavidAnson/markdownlint-cli2-action@992badcdf24e3b8eb7e87ff9287fe931bcb00c6e # v20.0.0
         with:
           config: .markdownlint-cli2.yaml
           globs: "**/*.md"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ issue template.
 
 ### F5 Contributor License Agreement (CLA)
 
-F5 requires all external contributors to agree to the terms of the F5 CLA (available [here](https://github.com/f5/.github/blob/main/CLA/cla-markdown.md))
+F5 requires all external contributors to agree to [the terms of the F5 CLA](https://github.com/f5/.github/blob/main/CLA/cla-markdown.md)
 before any of their changes can be incorporated into an F5 Open Source repository.
 
 If you have not yet agreed to the F5 CLA terms and submit a PR to this repository, a bot will prompt you to view and
@@ -76,8 +76,7 @@ can be merged. Your agreement signature will be safely stored by F5 and no longe
 
 - Keep a clean, concise and meaningful git commit history on your branch, rebasing locally and squashing before
   submitting a PR
-- Follow the guidelines of writing a good commit message as described here <https://chris.beams.io/posts/git-commit/>
-  and summarized in the next few points
+- Follow the [guidelines of writing a good commit message](<https://chris.beams.io/posts/git-commit/>) summarized in the next few points
   - In the subject line, use the present tense ("Add feature" not "Added feature")
   - In the subject line, use the imperative mood ("Move cursor to..." not "Moves cursor to...")
   - Limit the subject line to 72 characters or less
@@ -90,6 +89,6 @@ can be merged. Your agreement signature will be safely stored by F5 and no longe
 - Run `gofmt` over your code to automatically resolve a lot of style issues. Most editors support this running
   automatically when saving a code file.
 - Run `go lint` and `go vet` on your code too to catch any other issues.
-- Follow this guide on some good practice and idioms for Go - <https://github.com/golang/go/wiki/CodeReviewComments>
+- Follow [the guide](<https://github.com/golang/go/wiki/CodeReviewComments>) on some good practice and idioms for Go.
 - To check for extra issues, install [golangci-lint](https://github.com/golangci/golangci-lint) and run `make lint` or
   `golangci-lint run`


### PR DESCRIPTION
### Proposed changes

Correctly reference links in markdown - use descriptive names.

This PR fixes https://github.com/nginx/telemetry-exporter/pull/435/files

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [CONTRIBUTING](https://github.com/nginx/telemetry-exporter/blob/main/CONTRIBUTING.md) guide
- [X] I have proven my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [X] I have ensured the README is up to date
- [X] I have rebased my branch onto main
- [X] I will ensure my PR is targeting the main branch and pulling from my branch on my own fork
